### PR TITLE
feat: 종료버튼 tooltip 메세지 표현 기능 구현

### DIFF
--- a/src/components/common/CloseTooltip.js
+++ b/src/components/common/CloseTooltip.js
@@ -40,36 +40,36 @@ const boxFade = keyframes`
 `;
 
 const Content = styled.div`
+  position: absolute;
   display: none;
   flex-direction: column;
-  position: absolute;
   animation: ${boxFade} 0.2s ease;
   z-index: 9;
 `;
 
 const TextBox = styled.div`
   position: relative;
+  left: -70px;
   width: 100px;
-  background: #484848;
-  border-radius: 5px;
   padding: 8px;
+  border-radius: 5px;
+  -webkit-box-shadow: 0px 5px 17px 0px rgba(0, 0, 0, 0.64);
+  box-shadow: 0px 5px 17px 0px rgba(0, 0, 0, 0.64);
+  background: #484848;
   text-align: center;
   vertical-align: middle;
   color: white;
-  left: -70px;
-  -webkit-box-shadow: 0px 5px 17px 0px rgba(0, 0, 0, 0.64);
-  box-shadow: 0px 5px 17px 0px rgba(0, 0, 0, 0.64);
 
   &:after {
     content: "";
     position: absolute;
-    border-style: solid;
-    border-width: 0 10px 10px;
-    border-color: #484848 transparent;
-    display: block;
-    width: 0;
-    z-index: 1;
     top: -10px;
     left: 83px;
+    display: block;
+    width: 0;
+    border-width: 0 10px 10px;
+    border-color: #484848 transparent;
+    border-style: solid;
+    z-index: 1;
   }
 `;

--- a/src/components/common/CloseTooltip.js
+++ b/src/components/common/CloseTooltip.js
@@ -1,0 +1,75 @@
+import React from "react";
+import styled, { keyframes } from "styled-components";
+import PropTypes from "prop-types";
+
+export default function CloseTooltip({ children, message }) {
+  return (
+    <Container>
+      {children}
+      <Content id="tooltip">
+        <TextBox>{message}</TextBox>
+      </Content>
+    </Container>
+  );
+}
+
+CloseTooltip.propTypes = {
+  children: PropTypes.element.isRequired,
+  message: PropTypes.string.isRequired,
+};
+
+const Container = styled.div`
+  position: relative;
+  width: fit-content;
+  height: fit-content;
+
+  &:hover > #tooltip,
+  &:active > #tooltip {
+    display: block;
+  }
+`;
+
+const boxFade = keyframes`
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+`;
+
+const Content = styled.div`
+  display: none;
+  flex-direction: column;
+  position: absolute;
+  animation: ${boxFade} 0.2s ease;
+  z-index: 9;
+`;
+
+const TextBox = styled.div`
+  position: relative;
+  width: 100px;
+  background: #484848;
+  border-radius: 5px;
+  padding: 8px;
+  text-align: center;
+  vertical-align: middle;
+  color: white;
+  left: -70px;
+  -webkit-box-shadow: 0px 5px 17px 0px rgba(0, 0, 0, 0.64);
+  box-shadow: 0px 5px 17px 0px rgba(0, 0, 0, 0.64);
+
+  &:after {
+    content: "";
+    position: absolute;
+    border-style: solid;
+    border-width: 0 10px 10px;
+    border-color: #484848 transparent;
+    display: block;
+    width: 0;
+    z-index: 1;
+    top: -10px;
+    left: 83px;
+  }
+`;

--- a/src/layout/ServiceLayOut/Header.js
+++ b/src/layout/ServiceLayOut/Header.js
@@ -5,6 +5,7 @@ import { useParams } from "react-router-dom";
 import PropTypes from "prop-types";
 
 import { theme } from "../../config/constants";
+import CloseTooltip from "../../components/common/CloseTooltip";
 
 export default function Header({ title }) {
   const { channelId } = useParams();
@@ -19,9 +20,13 @@ export default function Header({ title }) {
 
   return (
     <Container color={channelId ? theme.white : theme.skyBlue}>
-      <CloseButton onClick={handleCloseButton}>
-        <CloseIcon />
-      </CloseButton>
+      <ButtonWrapper>
+        <CloseTooltip message="Back to Circle">
+          <CloseButton onClick={handleCloseButton}>
+            <CloseIcon />
+          </CloseButton>
+        </CloseTooltip>
+      </ButtonWrapper>
       <Title>{title}</Title>
     </Container>
   );
@@ -32,21 +37,26 @@ Header.propTypes = {
 };
 
 const Container = styled.div`
+  position: relative;
   background-color: ${(props) => props.color};
 `;
 
-const CloseButton = styled.button`
+const ButtonWrapper = styled.div`
+  display: inline;
   position: absolute;
   right: 0;
   top: 0;
   padding: 0;
+`;
+
+const CloseButton = styled.button`
   border: none;
   background-color: transparent;
 `;
 
 const CloseIcon = styled(IoMdCloseCircleOutline)`
   position: relative;
-  margin: 15px;
+  padding: 15px 15px 2px 2px;
   font-size: 30px;
   cursor: pointer;
 `;

--- a/src/pages/ChannelPage/index.js
+++ b/src/pages/ChannelPage/index.js
@@ -59,6 +59,7 @@ export default function ChannelPage() {
     <OnVolumeIcon
       onClick={handleOnMute}
       color={audioRefs.length ? "black" : `${theme.gray}`}
+      cursor={audioRefs.length ? "pointer" : "auto"}
     />
   );
 
@@ -157,19 +158,23 @@ const ControllerItemWrapper = styled.div`
 
 const OnMicIcon = styled(FaMicrophoneAlt)`
   font-size: 32px;
+  cursor: pointer;
 `;
 
 const OffMicIcon = styled(FaMicrophoneAltSlash)`
   font-size: 32px;
+  cursor: pointer;
 `;
 
 const OnVolumeIcon = styled(FaVolumeUp)`
   color: ${(props) => props.color};
   font-size: 32px;
+  cursor: ${(props) => props.cursor};
 `;
 
 const OffVolumeIcon = styled(FaVolumeMute)`
   font-size: 32px;
+  cursor: pointer;
 `;
 
 const LeaveButton = styled.button`


### PR DESCRIPTION
## 작업 사항
- 종료버튼에 툴팁메세지 추가
- 채널방 mic, 볼륨 아이콘 호버하면 커서모양 포인터로 변경
- Header 컴포넌트 layout에만 사용하므로 layout 폴더로 이동

https://user-images.githubusercontent.com/99335782/198106822-0a4a1c60-7e72-4858-8fba-1582cb1614d1.mov

## PR 전 확인사항
* [x] 가장 최신 브랜치를 pull했습니다.
* [x] base 브랜치명을 확인했습니다.
* [x] 코드 컨벤션을 모두 지켰습니다.
* [x] 적절한 라벨이 있습니다.
* [x] assignee가 있습니다.
* [ ] (필요한 경우) version 업데이트를 했습니다.

## 비고
- 어떻게하면 재사용성이 좋게 만들수있을까요?
- 툴팁의 좌표값, 크기는 일일이 지정해줘야할텐데...
