### PR TITLE
refactor: test코드 작성을위한 개발환경 목데이터 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,3 @@
 # misc
 .DS_Store
 .env
-
-# mockData
-/public/mockData

--- a/public/mockData/mock.json
+++ b/public/mockData/mock.json
@@ -1,0 +1,29 @@
+{
+  "_id": "635bb2b0a839de0976c242e6",
+  "secretKey": {
+    "iv": "7ca3cff067d41ad6981c25f3e5018322",
+    "key": "14541454e4116bcd156e3a991a221b78a6b14509aca303c899a28c71f624ab09",
+    "_id": "635bb2b0a839de0976c242e7"
+  },
+  "owner": "635b3a19d5d5b11394803c46",
+  "title": "바닐라 코딩",
+  "channels": [
+    {
+      "_id": "635c8458f0b2e0183c1db00a",
+      "title": "서비스 안내",
+      "description": "Circle이 궁금하다면..!",
+      "isActive": true,
+      "__v": 0
+    },
+    {
+      "_id": "635c8466f0b2e0183c1db014",
+      "title": "자유로운 대화",
+      "description": "blah blah",
+      "isActive": true,
+      "__v": 0
+    }
+  ],
+  "createdAt": "2022-10-28T10:45:04.508Z",
+  "updatedAt": "2022-10-29T01:39:50.670Z",
+  "__v": 0
+}

--- a/src/components/Channel/CalleeAudio.js
+++ b/src/components/Channel/CalleeAudio.js
@@ -17,9 +17,7 @@ export default function CalleeAudio({ peer, audioRefsDispatch }) {
   useEffect(() => {
     peer.on("stream", (stream) => {
       audioRef.current.srcObject = stream;
-      audioRef.current.play().catch(() => {
-        navigate("/");
-      });
+      audioRef.current.play();
 
       const audioRefInfo = {
         audioRef,

--- a/src/hooks/useConnection.js
+++ b/src/hooks/useConnection.js
@@ -48,15 +48,6 @@ export default function useConnection(channelId) {
 
             peer.id = calleeId;
 
-            peer.on("close", () => {
-              peer.removeAllListeners("close");
-              peer.destroy();
-            });
-
-            peer.on("error", () => {
-              navigate("/");
-            });
-
             return peer;
           });
 
@@ -82,15 +73,6 @@ export default function useConnection(channelId) {
           });
 
           peer.signal(payload.signal);
-
-          peer.on("close", () => {
-            peer.removeAllListeners("close");
-            peer.destroy();
-          });
-
-          peer.on("error", () => {
-            navigate("/");
-          });
 
           peer.id = payload.callerId;
 

--- a/src/layout/ServiceLayOut/Header.js
+++ b/src/layout/ServiceLayOut/Header.js
@@ -7,7 +7,7 @@ import PropTypes from "prop-types";
 import { theme } from "../../config/constants";
 import CloseTooltip from "../../components/common/CloseTooltip";
 
-export default function Header({ title }) {
+export default function Header({ title = "" }) {
   const { channelId } = useParams();
 
   const handleCloseButton = () => {
@@ -29,7 +29,11 @@ export default function Header({ title }) {
 }
 
 Header.propTypes = {
-  title: PropTypes.string.isRequired,
+  title: PropTypes.string,
+};
+
+Header.defaultProps = {
+  title: "",
 };
 
 const Container = styled.div`

--- a/src/layout/ServiceLayOut/index.js
+++ b/src/layout/ServiceLayOut/index.js
@@ -10,6 +10,19 @@ export default function ServiceLayOut() {
   const { channelId } = useParams();
 
   useEffect(() => {
+    if (process.env.REACT_APP_NODE_ENV === "development") {
+      const getData = async () => {
+        const response = await fetch("/mockData/mock.json");
+
+        const data = await response.json();
+        setProjectInfo(data);
+      };
+
+      getData();
+
+      return;
+    }
+
     const onLoadProject = (event) => {
       if (event.data) {
         setProjectInfo(JSON.parse(event.data));
@@ -19,6 +32,7 @@ export default function ServiceLayOut() {
     window.addEventListener("message", onLoadProject);
     window.parent.postMessage("getData", "*");
 
+    // eslint-disable-next-line consistent-return
     return () => {
       window.removeEventListener("message", onLoadProject);
     };

--- a/src/util/socketFactory.js
+++ b/src/util/socketFactory.js
@@ -11,6 +11,7 @@ const createSocket = () => {
     }
 
     socket = io(SOCKET_URL, {
+      path: "/circle-io",
       secure: true,
       reconnect: true,
       rejectUnauthorized: false,


### PR DESCRIPTION
## 작업 사항
- 테스트 코드 작성을 위한 개발환경일때의 목데이터를 추가하였습니다.
- 그외 피어 연결오류시 에러처리를 삭제함.
- 유저가 나가면 피어가 삭제되므로 에러를 무시하여도 될듯함
- 여기서 핸들링 하기어려운 에러는 "Failed to execute 'setLocalDescription' on 'RTCPeerConnection'" 이런 에러인데 자세한건 이슈에 올리겠습니다 #6 

## PR 전 확인사항
* [x] 가장 최신 브랜치를 pull했습니다.
* [x] base 브랜치명을 확인했습니다.
* [x] 코드 컨벤션을 모두 지켰습니다.
* [x] 적절한 라벨이 있습니다.
* [x] assignee가 있습니다.
* [ ] (필요한 경우) version 업데이트를 했습니다.

## 비고
- 참고 사항을 적어주세요. (ex. 관련 링크, MR 순서)
