### PR TITLE
[2022.11.01] refactor: webRTC 부분 턴서버 명시, peerRef로 안전하게 관리, spinner 컴포넌트 추가

### DIFF
--- a/src/components/Channel/CalleeAudio.js
+++ b/src/components/Channel/CalleeAudio.js
@@ -1,18 +1,17 @@
 import React, { useEffect, useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import styled from "styled-components";
 import PropTypes from "prop-types";
 import Peer from "simple-peer";
 
 import { audioRefsAction } from "../../reducer/actions";
-import LoadingIcon from "../shared/LoadingUserIcon";
 import UserIcon from "../shared/UserIcon";
 import StyledAudio from "../shared/StyledAudio";
 import AudioWrapper from "../shared/AudioWrapper";
+import Spinner from "../shared/Spinner";
 
 export default function CalleeAudio({ peer, audioRefsDispatch }) {
-  const audioRef = useRef();
   const [isLoading, setIsLoading] = useState(true);
-  const navigate = useNavigate();
+  const audioRef = useRef();
 
   useEffect(() => {
     peer.on("stream", (stream) => {
@@ -27,12 +26,12 @@ export default function CalleeAudio({ peer, audioRefsDispatch }) {
       setIsLoading(false);
       audioRefsDispatch({ type: audioRefsAction.ADD, payload: audioRefInfo });
     });
-  }, [audioRefsDispatch, navigate, peer]);
+  }, [audioRefsDispatch, peer]);
 
   return (
     <AudioWrapper>
-      {isLoading ? <LoadingIcon /> : <UserIcon />}
-      <StyledAudio playsInline autoPlay ref={audioRef} />
+      {isLoading ? <CustomSpinner /> : <UserIcon />}
+      <StyledAudio autoplay ref={audioRef} />
     </AudioWrapper>
   );
 }
@@ -41,3 +40,8 @@ CalleeAudio.propTypes = {
   peer: PropTypes.instanceOf(Peer).isRequired,
   audioRefsDispatch: PropTypes.func.isRequired,
 };
+
+const CustomSpinner = styled(Spinner)`
+  width: 30px;
+  height: 30px;
+`;

--- a/src/components/Channel/CalleeAudio.js
+++ b/src/components/Channel/CalleeAudio.js
@@ -31,7 +31,7 @@ export default function CalleeAudio({ peer, audioRefsDispatch }) {
   return (
     <AudioWrapper>
       {isLoading ? <CustomSpinner /> : <UserIcon />}
-      <StyledAudio autoplay ref={audioRef} />
+      <StyledAudio playsInline autoplay ref={audioRef} />
     </AudioWrapper>
   );
 }

--- a/src/components/shared/Spinner.js
+++ b/src/components/shared/Spinner.js
@@ -1,0 +1,21 @@
+import styled, { keyframes } from "styled-components";
+
+const spinnerAnima = keyframes`
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+`;
+
+const Spinner = styled.div`
+  width: 50px;
+  height: 50px;
+  border: 10px solid #f3f3f3;
+  border-top: 10px solid #383636;
+  border-radius: 50%;
+  animation: ${spinnerAnima} 1.5s linear infinite;
+`;
+
+export default Spinner;

--- a/src/hooks/useConnection.js
+++ b/src/hooks/useConnection.js
@@ -1,5 +1,4 @@
 import { useEffect, useReducer, useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
 import Peer from "simple-peer";
 
 import { audioRefsAction, peersAction } from "../reducer/actions";
@@ -13,7 +12,7 @@ export default function useConnection(channelId) {
   const [err, setErr] = useState(null);
   const socket = useSocket();
   const myAudio = useRef();
-  const navigate = useNavigate();
+  const peersRef = useRef([]);
 
   useEffect(() => {
     const connectRTC = async () => {
@@ -32,13 +31,28 @@ export default function useConnection(channelId) {
               initiator: true,
               trickle: false,
               stream,
+              config: {
+                iceServers: [
+                  { urls: "stun:stun.l.google.com:19302" },
+                  { urls: "stun:stun1.l.google.com:19302" },
+                  { urls: "stun:stun2.l.google.com:19302" },
+                  { urls: "stun:stun3.l.google.com:19302" },
+                  { urls: "stun:stun4.l.google.com:19302" },
+                  {
+                    url: "turn:turn.bistri.com:80",
+                    credential: "homeo",
+                    username: "homeo",
+                  },
+                  {
+                    url: "turn:turn.anyfirewall.com:443?transport=tcp",
+                    credential: "webrtc",
+                    username: "webrtc",
+                  },
+                ],
+              },
             });
 
             peer.on("signal", (signal) => {
-              if (signal.renegotiate || signal.transceiverRequest) {
-                return;
-              }
-
               socket.emit(CHANNEL.OFFER, {
                 calleeId,
                 callerId: socket.id,
@@ -51,6 +65,8 @@ export default function useConnection(channelId) {
             return peer;
           });
 
+          peersRef.current = newPeers;
+
           peersDispatch({ type: peersAction.INIT, payload: newPeers });
         });
 
@@ -59,28 +75,49 @@ export default function useConnection(channelId) {
             initiator: false,
             trickle: false,
             stream,
+            config: {
+              iceServers: [
+                { urls: "stun:stun.l.google.com:19302" },
+                { urls: "stun:stun1.l.google.com:19302" },
+                { urls: "stun:stun2.l.google.com:19302" },
+                { urls: "stun:stun3.l.google.com:19302" },
+                { urls: "stun:stun4.l.google.com:19302" },
+                {
+                  url: "turn:turn.bistri.com:80",
+                  credential: "homeo",
+                  username: "homeo",
+                },
+                {
+                  url: "turn:turn.anyfirewall.com:443?transport=tcp",
+                  credential: "webrtc",
+                  username: "webrtc",
+                },
+              ],
+            },
           });
 
           peer.on("signal", (signal) => {
-            if (signal.renegotiate || signal.transceiverRequest) {
-              return;
-            }
-
             socket.emit(CHANNEL.ANSWER, {
               callerId: payload.callerId,
               signal,
             });
           });
 
-          peer.signal(payload.signal);
-
           peer.id = payload.callerId;
 
-          peersDispatch({ type: peersAction.ADD, payload: peer });
+          peer.signal(payload.signal);
+
+          peersRef.current.push(peer);
+
+          peersDispatch({ type: peersAction.ADD, payload: peersRef });
         });
 
         socket.on(CHANNEL.RETURN_SIGNAL, (payload) => {
-          peersDispatch({ type: peersAction.SIGNAL, payload });
+          const targetPeer = peersRef.current.find(
+            (peer) => peer.id === payload.calleeId
+          );
+
+          targetPeer.signal(payload.signal);
         });
 
         socket.on(CHANNEL.USER_DISCONNECT, (targetId) => {
@@ -89,7 +126,17 @@ export default function useConnection(channelId) {
             payload: targetId,
           });
 
-          peersDispatch({ type: peersAction.DISCONNECT, payload: targetId });
+          const targetPeer = peersRef.current.find(
+            (peer) => peer.id === targetId
+          );
+
+          targetPeer?.destroy();
+
+          peersRef.current = peersRef.current.filter(
+            (peer) => peer.id !== targetId
+          );
+
+          peersDispatch({ type: peersAction.DISCONNECT, payload: peersRef });
         });
       } catch (error) {
         setErr("미디어 장치가 없습니다");
@@ -99,7 +146,7 @@ export default function useConnection(channelId) {
     if (socket) {
       connectRTC();
     }
-  }, [channelId, navigate, socket]);
+  }, [channelId, socket]);
 
   return {
     peers,

--- a/src/hooks/useConnection.js
+++ b/src/hooks/useConnection.js
@@ -109,7 +109,7 @@ export default function useConnection(channelId) {
 
           peersRef.current.push(peer);
 
-          peersDispatch({ type: peersAction.ADD, payload: peersRef });
+          peersDispatch({ type: peersAction.ADD, payload: peer });
         });
 
         socket.on(CHANNEL.RETURN_SIGNAL, (payload) => {
@@ -136,7 +136,7 @@ export default function useConnection(channelId) {
             (peer) => peer.id !== targetId
           );
 
-          peersDispatch({ type: peersAction.DISCONNECT, payload: peersRef });
+          peersDispatch({ type: peersAction.DISCONNECT, payload: targetId });
         });
       } catch (error) {
         setErr("미디어 장치가 없습니다");

--- a/src/hooks/useSocket.js
+++ b/src/hooks/useSocket.js
@@ -23,11 +23,10 @@ export default function useSocket() {
 
     return () => {
       if (socket) {
-        socket.off(CHANNEL.ANSWER);
         socket.off(CHANNEL.EXISTED_CALLEES);
+        socket.off(CHANNEL.USER_JOIN);
         socket.off(CHANNEL.RETURN_SIGNAL);
         socket.off(CHANNEL.USER_DISCONNECT);
-        socket.off(CHANNEL.OFFER);
         socket.disconnect();
       }
     };

--- a/src/pages/ChannelPage/index.js
+++ b/src/pages/ChannelPage/index.js
@@ -83,7 +83,7 @@ export default function ChannelPage() {
                 audioRefsDispatch={audioRefsDispatch}
               />
               <ChannelDescription>
-                {audioRefs.length + 1}명 접속중 입니다
+                {peers.length + 1}명 접속중 입니다
               </ChannelDescription>
             </>
           )}

--- a/src/reducer/index.js
+++ b/src/reducer/index.js
@@ -5,26 +5,12 @@ export const peersReducer = (state, { type, payload }) => {
     return payload;
   }
 
-  if (type === peersAction.SIGNAL) {
-    const targetPeer = state.find((peer) => peer.id === payload.calleeId);
-    targetPeer.signal(payload.signal);
-
-    return state;
+  if (type === peersAction.ADD) {
+    return [...payload.current];
   }
 
   if (type === peersAction.DISCONNECT) {
-    const targetPeer = state.find((peer) => peer.id === payload);
-
-    if (targetPeer) {
-      targetPeer.removeAllListeners("close");
-      targetPeer.destroy();
-    }
-
-    return state.filter((peer) => peer.id !== payload);
-  }
-
-  if (type === peersAction.ADD) {
-    return [...state, payload];
+    return [...payload.current];
   }
 
   return state;

--- a/src/reducer/index.js
+++ b/src/reducer/index.js
@@ -6,11 +6,11 @@ export const peersReducer = (state, { type, payload }) => {
   }
 
   if (type === peersAction.ADD) {
-    return [...payload.current];
+    return [...state, payload];
   }
 
   if (type === peersAction.DISCONNECT) {
-    return [...payload.current];
+    return state.filter((peer) => peer.id !== payload);
   }
 
   return state;


### PR DESCRIPTION
## 작업 사항
- 구글의 스턴서버와 구글 턴서버까지 사용하여 RTC연결의 안정성을 높힘. (스턴서버로 연결이 실패할시 턴서버로 연결이 진행됨)
- 기존의 peer 연결시 state값을 빼올려고 dispatch를 이용하여 peer를 사용하다보니 비동기적으로 한번에 작용하는 dispatch가 예측 하기 어려워 peer연결시에는 재렌더링을 막고자 useRef로 피어를 관리하고 연결시, 연결이 끊길시에 useRef에 있는 피어를 이용하였습니다.

- 기존의 소켓의 이벤트를 구독취소 안된부분이있어서 socket.off 수정

- 로딩 스피너 컴포넌트를 추가하였습니다

https://user-images.githubusercontent.com/99335782/199238400-caa58242-df76-490d-80fc-7095f48534a3.mov




## 잘 봐주세요
- useRef의 필요성 및 peer 의 렌더링 순서

## PR 전 확인사항
* [x] 가장 최신 브랜치를 pull했습니다.
* [x] base 브랜치명을 확인했습니다.
* [x] 코드 컨벤션을 모두 지켰습니다.
* [x] 적절한 라벨이 있습니다.
* [x] assignee가 있습니다.
* [ ] (필요한 경우) version 업데이트를 했습니다.

## 비고
peer가 렌더링 되기전에 stream이 연결 되어서 한쪽에서는 연결이 안된것처럼 보이는 현상이 일어나는 것 같습니다.
state의 비동기적 현상과 서버에 송수신의 순서를 예측할수가 없어서 어떻게 수정해야할지 고민입니다.
#16 